### PR TITLE
load all_baseline before subsetting

### DIFF
--- a/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_formation_and_breakdown.py
+++ b/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_formation_and_breakdown.py
@@ -23,7 +23,8 @@ savedir, fig_panel_str = figure_helper.get_save_dir_and_fig_panel_str(figure, pa
 colony = "medium"
 
 #  load the tracking CSV for medium from FMS
-df = global_dataset_filtering.load_dataset_with_features(colony)
+df = global_dataset_filtering.load_dataset_with_features()
+df = df[df["colony"] == colony]
 df_fmb = figure_helper.assemble_formation_middle_breakdown_dataframe(df)
 # load the images for each timepoint
 # %%

--- a/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_processing_workflow.py
+++ b/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_processing_workflow.py
@@ -41,7 +41,8 @@ cell_color = np.asarray([0, 255, 255])
 # show segmentations as sum projections of contours to emphasize 3D ness
 use_cv_contours_for_3d = False
 
-df = load_dataset_with_features(colony)
+df = load_dataset_with_features()
+df = df[df.colony == colony]
 df["centroid_y_inv"] = 3120 - df["centroid_y"].values  # seg.shape[1]-cy
 df["centroid_z_inv"] = 109 - df["centroid_z"].values  # seg.shape[0]-cz
 df["centroid_z_inv_adjust"] = (

--- a/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_save_3d_image_for_agave.py
+++ b/nuc_morph_analysis/analyses/dataset_images_for_figures/figure_dataset_save_3d_image_for_agave.py
@@ -35,7 +35,8 @@ cell_color = np.asarray([255, 255, 0])
 # show segmentations as sum projections of contours to emphasize 3D ness
 use_cv_contours_for_3d = False
 
-df = load_dataset_with_features(name)
+df = load_dataset_with_features()
+df = df[df.colony == name]
 
 # %%
 # find the label number for the chosen track


### PR DESCRIPTION
Our load dataset functions do not currently support loading subset colony datasets using the keys: `"small", "medium", "large"`. Updated figure 1 workflows to load "all_baseline" before subsetting to a particular colony. This update makes sure `figure1_dataset` succeeds when running `run_all_manuscript_workflows.py`.

```
====== Successes ======
figure1_dataset (1927.0s) (48.0GB)
====== 1 succeeded  ======
```

A future PR could update the load dataset functions to work with the colony keys. 
