### PR TITLE
Bugfix: perturbation manifest `.items()`

### DIFF
--- a/nuc_morph_analysis/lib/preprocessing/load_data.py
+++ b/nuc_morph_analysis/lib/preprocessing/load_data.py
@@ -119,7 +119,7 @@ def get_available_datasets(experiments=["baseline"]):
     """
     names = [
         name
-        for name, info in datasets.items
+        for name, info in datasets.items()
         if (
             (name not in ["all_baseline", "all_feeding_control", "all_drug_perturbation"])
             and (info["experiment"] in experiments)


### PR DESCRIPTION
# Issue
In 9f21bab I broke pushed a change that broke `load_data.get_available_datasets` and therefore `generate_perturbation_manifest.py`.

# Testing
Re-ran `generate_perturbation_manifest.py` and compared both the outputs to those published to quilt.