### PR TITLE
timelapse feature explorer update

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -662,7 +662,7 @@ name = "colorizer-data"
 version = "0.0.0"
 requires_python = ">=3.8"
 git = "https://github.com/allen-cell-animated/colorizer-data.git"
-ref = "v1.4.0"
+ref = "v1.4.1"
 revision = "8e4a505902ac5eb50bef35a6f82aaa186e6d8c3e"
 summary = "Utilities to convert data for viewing in Timelapse Colorizer"
 dependencies = [

--- a/pdm.lock
+++ b/pdm.lock
@@ -662,7 +662,7 @@ name = "colorizer-data"
 version = "0.0.0"
 requires_python = ">=3.8"
 git = "https://github.com/allen-cell-animated/colorizer-data.git"
-ref = "v1.2.0"
+ref = "v1.4.0"
 revision = "8e4a505902ac5eb50bef35a6f82aaa186e6d8c3e"
 summary = "Utilities to convert data for viewing in Timelapse Colorizer"
 dependencies = [


### PR DESCRIPTION
Update pdm.lock file to latest version of colorizer-data version v1.4.1 which saves the tfe outputs in parquets instead of json which speeds up dataset loading performance on timelapse feature explorer! 

FIles on quilt have already been updated to match this change. 