### PR TITLE
Linear regression

### DIFF
--- a/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
+++ b/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
@@ -17,6 +17,7 @@ from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 from nuc_morph_analysis.lib.preprocessing import global_dataset_filtering, filter_data
 from sklearn.model_selection import permutation_test_score
+from nuc_morph_analysis.lib.visualization.plotting_tools import get_plot_labels_for_metric
 
 pd.options.mode.chained_assignment = None  # default='warn'
 
@@ -157,11 +158,11 @@ def fit_linear_regression(
     all_perms.to_csv(save_path / "perm_scores.csv")
 
     # Save coefficient plot for max alpha value
-    save_plots(all_coef_alpha, all_test_sc, all_perms, save_path)
+    save_plots(all_coef_alpha, all_test_sc, all_perms, target, save_path)
 
     return all_coef_alpha, all_test_sc, all_perms
 
-def save_plots(all_coef_alpha, all_test_sc, all_perms, save_path):
+def save_plots(all_coef_alpha, all_test_sc, all_perms, target, save_path):
 
     # subset to max alpha
     max_alpha = all_coef_alpha['alpha'].max()
@@ -185,9 +186,10 @@ def save_plots(all_coef_alpha, all_test_sc, all_perms, save_path):
     )
     g.fig.subplots_adjust(top=0.8) # adjust the Figure in rp
     g.fig.suptitle(f'p-value {p_value}, test r^2 {test_r2_mean}+-{test_r2_std}')
-    g.set_xticklabels(rotation=90)
-    print(f'Saving coefficients_{max_alpha}.png')
-    g.savefig(save_path / f'coefficients_{max_alpha}.png')
+    label_list = [get_plot_labels_for_metric(col)[1] for col in all_coef_alpha['Column'].unique()]
+    g.set_xticklabels(label_list, rotation=90)
+    print(f'Saving coefficients_{target}_alpha_{max_alpha}.png')
+    g.savefig(save_path / f'coefficients_{target}_alpha_{max_alpha}.png')
 
 def list_of_strings(arg):
     return arg.split(",")

--- a/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
+++ b/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
@@ -1,0 +1,259 @@
+import argparse
+import ast
+import os
+import warnings
+from pathlib import Path
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from sklearn import linear_model
+from sklearn.model_selection import (
+    RepeatedKFold,
+    cross_validate,
+)
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+from nuc_morph_analysis.lib.preprocessing import global_dataset_filtering, filter_data
+from sklearn.model_selection import permutation_test_score
+
+pd.options.mode.chained_assignment = None  # default='warn'
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+def main(cols, target, alpha_range, tolerance, save_path, cached_dataframe=None):
+
+    save_path = Path(save_path)
+    save_path.mkdir(parents=True, exist_ok=True)
+
+    if not cached_dataframe:
+        df_all = global_dataset_filtering.load_dataset_with_features()
+        df_full = filter_data.all_timepoints_full_tracks(df_all)
+        df_track_level_features = filter_data.track_level_features(df_full)
+    else:
+        df_track_level_features = pd.read_csv(cached_dataframe)
+
+    fit_linear_regression(df_track_level_features, cols, target, alpha_range, tolerance, save_path)
+
+def fit_linear_regression(
+    data, cols, target, alpha, tol, save_path
+):
+    """
+    data - track level features
+    cols - input features
+    target - target to predict
+    alpha - hyperparameter for lasso
+    save_path - location to save files
+    """
+    sns.set_context("talk")
+    random_state = 2652124
+
+    # init empty dicts and lists
+    all_test_sc = []
+    all_coef_alpha = []
+    all_perms = {'score': [], 'perm_score_mean': [], 'perm_score_std': [], 'p_value': [], 'alpha': []}
+
+    # find best alpha for Lasso model
+    for alpha_ind, this_alpha in enumerate(alpha):
+        all_coefs = []
+        print("fitting alpha", this_alpha)
+
+        # drop any nan rows
+        dropna_cols = cols + [target]
+        data = data.dropna(subset=dropna_cols)
+
+        # make numpy array for inputs and target
+        all_input = data[cols].reset_index(drop=True).values
+        all_target = data[target].values
+
+        if this_alpha == 0:
+            # linear regression if alpha == 0
+            clf = linear_model.LinearRegression()
+        else:
+            clf = linear_model.Lasso(alpha=this_alpha)
+
+        # normalize input features
+        model = make_pipeline(StandardScaler(), clf)
+
+        # run permutation test
+        score, permutation_scores, pvalue = permutation_test_score(
+            model, all_input, all_target, random_state=random_state, cv=5, n_permutations=500,
+        )
+
+        # break if permutation score is less than linear regression value (max possible)
+        # with a tolerance
+        # or if p_value > 0.05
+        rounded_permutation_score = round(score, 2)
+        if alpha_ind == 0:
+            max_val = rounded_permutation_score
+        if abs(rounded_permutation_score - max_val) > tol or (pvalue > 0.05):
+            break
+
+        # if relatively equal to linear regression value, then continue
+        # save permutation score and p_value to dictionary
+        all_perms['score'].append(score)
+        all_perms['perm_score_mean'].append(permutation_scores.mean())
+        all_perms['perm_score_std'].append(permutation_scores.std())
+        all_perms['p_value'].append(pvalue)
+        all_perms['alpha'].append(this_alpha)
+
+        # run cross validate to get model coefficients
+        cv_model = cross_validate(
+            model,
+            all_input,
+            all_target,
+            cv=RepeatedKFold(n_splits=5, n_repeats=20, random_state=random_state),
+            return_estimator=True,
+            n_jobs=2,
+            scoring=[
+                "r2",
+                "explained_variance",
+                "neg_mean_absolute_error",
+                "max_error",
+                "neg_mean_squared_error",
+                "neg_mean_absolute_percentage_error",
+            ],
+            return_train_score=True,
+        )
+
+        # Save test r^2 and test MSE to dataframe
+        range_test_scores = [round(i, 2) for i in cv_model["test_r2"]]
+        range_errors = [
+            round(i, 2) for i in cv_model["test_neg_mean_squared_error"]
+        ]
+        test_sc = pd.DataFrame()
+        test_sc[r"Test r$^2$"] = range_test_scores
+        test_sc["Test MSE"] = range_errors
+        test_sc["alpha"] = this_alpha
+        all_test_sc.append(test_sc)
+
+        # Save coeffs to dataframe
+        coefs = pd.DataFrame(
+            [model[1].coef_ for model in cv_model["estimator"]], columns=cols
+        )
+
+        all_coefs.append(coefs)
+        all_coefs = pd.concat(all_coefs, axis=0).reset_index(drop=True)
+        all_coefs["alpha"] = this_alpha
+        all_coef_alpha.append(all_coefs)
+
+    # Get test scores for all alpha
+    all_test_sc = pd.concat(all_test_sc, axis=0).reset_index(drop=True)
+    all_test_sc["Test MSE"] = -all_test_sc["Test MSE"]
+    all_test_sc.to_csv(save_path / "mse.csv")
+
+    # Get coeffs for all alpha
+    all_coef_alpha = pd.concat(all_coef_alpha, axis=0).reset_index(drop=True)
+    all_coef_alpha = all_coef_alpha.melt(
+        id_vars=["alpha"],
+        var_name="Column",
+        value_name="Coefficient Importance",
+    ).reset_index(drop=True)
+    all_coef_alpha.to_csv(save_path / "coefficients.csv")
+
+    # Get permutation scores and p values for all alpha
+    all_perms = pd.DataFrame(all_perms).reset_index(drop=True)
+    all_perms.to_csv(save_path / "perm_scores.csv")
+
+    # Save coefficient plot for max alpha value
+    save_plots(all_coef_alpha, all_test_sc, all_perms, save_path)
+
+    return all_coef_alpha, all_test_sc, all_perms
+
+def save_plots(all_coef_alpha, all_test_sc, all_perms, save_path):
+
+    # subset to max alpha
+    max_alpha = all_coef_alpha['alpha'].max()
+    all_coef_alpha = all_coef_alpha.loc[all_coef_alpha['alpha'] == max_alpha].reset_index(drop=True)
+    all_test_sc = all_test_sc.loc[all_test_sc['alpha'] == max_alpha].reset_index(drop=True)
+    all_perms = all_perms.loc[all_perms['alpha'] == max_alpha].reset_index(drop=True)
+
+    p_value = round(all_perms['p_value'].item(), 3)
+    test_r2_mean = round(all_test_sc['Test r$^2$'].mean(), 2)
+    test_r2_std = round(all_test_sc['Test r$^2$'].std()/2, 2)
+
+
+    g = sns.catplot(
+        data=all_coef_alpha,
+        x='Column',
+        y="Coefficient Importance",
+        kind="bar",
+        errorbar="sd",
+        aspect=1.5,
+        height=4,
+    )
+    g.fig.subplots_adjust(top=0.8) # adjust the Figure in rp
+    g.fig.suptitle(f'p-value {p_value}, test r^2 {test_r2_mean}+-{test_r2_std}')
+    g.set_xticklabels(rotation=90)
+    print(f'Saving coefficients_{max_alpha}.png')
+    g.savefig(save_path / f'coefficients_{max_alpha}.png')
+
+def list_of_strings(arg):
+    return arg.split(",")
+
+
+def list_of_floats(arg):
+    return list(map(float, arg.split(",")))
+
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "False", "f", "n", "0"):
+        return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the linear regression workflow")
+    # Optional command line argument
+    parser.add_argument(
+        "--cached_dataframe",
+        type=str,
+        metavar="path",
+        help="Supply a path to a dataframe to skip data preprocessing. If included, dataframe "
+        "should match the result of linear_regression_analysis.get_data (see source code for "
+        "details).",
+    )
+
+    parser.add_argument(
+        "--cols",
+        type=list_of_strings,
+        default=['volume_at_B', 'time_at_B', 'colony_time_at_B', 'SA_at_B'],
+        help="Supply a list of column names to use as independent variables in the linear regression analysis.",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="duration_BC",
+        help="Supply a column name for a dependent variable to perform regression on",
+    )
+    parser.add_argument(
+        "--alpha_range",
+        type=list_of_floats,
+        default=[1.3],
+        help="Supply a list of alpha values to use in lasso regression",
+    )
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default="figures",
+        help="local folder name where plots will be saved",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.02,
+        help="Tolerace for change in regression score to determine best alpha",
+    )
+    args = parser.parse_args()
+    main(
+        cols=args.cols,
+        target=args.target,
+        alpha_range=args.alpha_range,
+        tolerance=args.tolerance,
+        save_path=args.save_path,
+        cached_dataframe=args.cached_dataframe
+    )

--- a/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
+++ b/nuc_morph_analysis/analyses/linear_regression/linear_regression_workflow.py
@@ -26,6 +26,7 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 def main(cols, target, alpha_range, tolerance, save_path, cached_dataframe=None):
 
     save_path = Path(save_path)
+    save_path = save_path / Path("linear_regression")
     save_path.mkdir(parents=True, exist_ok=True)
 
     if not cached_dataframe:
@@ -45,6 +46,7 @@ def fit_linear_regression(
     cols - input features
     target - target to predict
     alpha - hyperparameter for lasso
+    tol - tolerance to check drop in r^2 for finding best alpha (ex. 0.02)
     save_path - location to save files
     """
     sns.set_context("talk")
@@ -57,7 +59,6 @@ def fit_linear_regression(
 
     # find best alpha for Lasso model
     for alpha_ind, this_alpha in enumerate(alpha):
-        all_coefs = []
         print("fitting alpha", this_alpha)
 
         # drop any nan rows
@@ -134,10 +135,8 @@ def fit_linear_regression(
             [model[1].coef_ for model in cv_model["estimator"]], columns=cols
         )
 
-        all_coefs.append(coefs)
-        all_coefs = pd.concat(all_coefs, axis=0).reset_index(drop=True)
-        all_coefs["alpha"] = this_alpha
-        all_coef_alpha.append(all_coefs)
+        coefs["alpha"] = this_alpha
+        all_coef_alpha.append(coefs)
 
     # Get test scores for all alpha
     all_test_sc = pd.concat(all_test_sc, axis=0).reset_index(drop=True)

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/added_volume.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/added_volume.sh
@@ -2,4 +2,4 @@ python linear_regression_workflow.py \
 --cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
 --alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10,11,12,13 \
 --target 'delta_volume_BC' \
---save_path "delta_volume_BC" \
+--save_path "../../figures/" \

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/added_volume.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/added_volume.sh
@@ -1,0 +1,5 @@
+python linear_regression_workflow.py \
+--cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
+--alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10,11,12,13 \
+--target 'delta_volume_BC' \
+--save_path "delta_volume_BC" \

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/duration_BC.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/duration_BC.sh
@@ -2,4 +2,4 @@ python linear_regression_workflow.py \
 --cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
 --alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10 \
 --target 'duration_BC' \
---save_path "duration_BC" \
+--save_path "../../figures/" \

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/duration_BC.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/duration_BC.sh
@@ -1,0 +1,5 @@
+python linear_regression_workflow.py \
+--cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
+--alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10 \
+--target 'duration_BC' \
+--save_path "duration_BC" \

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/ending_volume.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/ending_volume.sh
@@ -1,0 +1,5 @@
+python linear_regression_workflow.py \
+--cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
+--alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10,11,12,13 \
+--target 'volume_at_C' \
+--save_path "volume_at_C" \

--- a/nuc_morph_analysis/analyses/linear_regression/scripts/ending_volume.sh
+++ b/nuc_morph_analysis/analyses/linear_regression/scripts/ending_volume.sh
@@ -2,4 +2,4 @@ python linear_regression_workflow.py \
 --cols 'volume_at_A','volume_at_B','time_at_A','time_at_B','colony_time_at_A','colony_time_at_B','SA_at_B' \
 --alpha_range 0,0.1,0.5,1,1.3,1.5,2,2.5,5,10,11,12,13 \
 --target 'volume_at_C' \
---save_path "volume_at_C" \
+--save_path "../../figures/" \


### PR DESCRIPTION
Re-adds linear regression workflow for single timepoints prediction based on conversation with @chantelleleveille and @cfrick13. Scripts to run 

`./analyses/linear_regression/scripts/duration_BC.sh`
`./analyses/linear_regression/scripts/ending_volume.sh`
`./analyses/linear_regression/scripts/added_volume.sh`

Example result plot for duration_BC prediction using alpha=1.5 (the largest alpha that did not decrease r^2 by a significant amount, defined via a tolerance hyperparameter = 0.02) - 

![Screen Shot 2024-09-16 at 8 34 58 AM](https://github.com/user-attachments/assets/9e3d870f-35f0-4e91-aeae-92ed461ace5a)

p-value is obtained via a permutation test (Neda had requested this a while ago). This is the number of permuted scores that are greater than the real score with correct ordering.

I used whatever features I could find in `df_track_level_features` from `filter_data.track_level_features`. Let me know what else I can add!
 