### PR TITLE
update dependencies based on fixing colorizer package version update

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "internal"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:d7f198ce7a17f74254209ca4ba4eaf3e2903219887d512d619d73bba2cb12e52"
+content_hash = "sha256:cd0afe7e33642ec6becfa8bca18a94426474c1326998ececa9a5b8820a8a4716"
 
 [[package]]
 name = "aicscytoparam"
@@ -659,17 +659,18 @@ files = [
 
 [[package]]
 name = "colorizer-data"
-version = "0.0.0"
+version = "1.4.2"
 requires_python = ">=3.8"
 git = "https://github.com/allen-cell-animated/colorizer-data.git"
 ref = "v1.4.2"
-revision = "8e4a505902ac5eb50bef35a6f82aaa186e6d8c3e"
+revision = "7f7926826a144de540f0c89d38c5388ca5952074"
 summary = "Utilities to convert data for viewing in Timelapse Colorizer"
 dependencies = [
     "dataclasses-json",
     "numpy",
     "pandas",
     "pillow",
+    "pyarrow",
     "requests",
     "scikit-image",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "termcolor>=2.4.0",
     "cvapipe-analysis>=0.2.0",
     "vtk-osmesa>=9.3.0",
-    "colorizer-data @ git+https://github.com/allen-cell-animated/colorizer-data.git@v1.2.0",
+    "colorizer-data @ git+https://github.com/allen-cell-animated/colorizer-data.git@v1.4.2",
     "bioio-ome-zarr>=1.0.1",
     "bioio>=1.0.2",
     "bioio-base>=1.0.1",


### PR DESCRIPTION
The `colorizer-data` dependency was updated for the implementation of the glossary. This adapts a previous change to how this dependency was updated (PR #27).