### PR TITLE
Height percentile fix

### DIFF
--- a/nuc_morph_analysis/lib/preprocessing/load_data.py
+++ b/nuc_morph_analysis/lib/preprocessing/load_data.py
@@ -52,15 +52,19 @@ def get_dataframe_by_info(info):
     # Load dataframe by file format
     if path.endswith("csv"):
         df = pd.read_csv(path)
+        
         # use height calculated from 1st to 99th percentile values
         # rather than the most extreme values
-        df["height"] = df["height_percentile"]
+        if "height_percentile" in df.columns: # only some datasets have this column
+            df["height"] = df["height_percentile"]
         return df
     elif path.endswith("parquet"):
         df = pd.read_parquet(path)
+        
         # use height calculated from 1st to 99th percentile values
         # rather than the most extreme values
-        df["height"] = df["height_percentile"]
+        if "height_percentile" in df.columns: # only some datasets have this column
+            df["height"] = df["height_percentile"]
         return df
     else:
         raise ValueError(f"Unknown format {path.split('.')[-1]}")


### PR DESCRIPTION
# overview
Ran into an error when re-testing `generate_main_manifest.py` in another branch. 

The error occured in `get_dataframe_by_info` which is called by three functions:
1. `load_morflowgenesis_dataframe`: this loads morflowgenesis manifests, which do contain `height_percentile`. 
2. `load_lineage_annotations`: this loads lineage annotations which do not contain 'height_percentile` column so this errored. 
3. `load_apoptosis_annotations`: these do not contain 'height_percentile` column and therefore gave an error.  

The fix I make simply checks if `height_percentile` is a column, and if it is, then `height` is replaced with `height_percentile`. 

# test
I reran `generate_main_manifest.py` and confirmed that this section of code no longer errors. 