### PR TITLE
Update requirements.txt files on bioRxv-v1 and dev branches

### DIFF
--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -96,12 +96,12 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          base: main
+          base: ${{ github.ref_name }}
           title: admin/requirements-update_${{ steps.timestamp.outputs.timestamp }}
           body: Updating requirements.txt.
 
             Due to some [challenges](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs),
             with getting this PR to trigger the tests, please manually close and re-open this PR.
           branch: admin/requirements-update_${{ steps.timestamp.outputs.timestamp }}
-          commit-message: Updating requirements.txt after change to `pdm.lock` was pushed to `main`
+          commit-message: Updating requirements.txt after change to `pdm.lock` was pushed to `${{ github.head_ref || github.ref_name }}`
           delete-branch: true

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -103,5 +103,5 @@ jobs:
             Due to some [challenges](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs),
             with getting this PR to trigger the tests, please manually close and re-open this PR.
           branch: admin/requirements-update_${{ steps.timestamp.outputs.timestamp }}
-          commit-message: Updating requirements.txt after change to `pdm.lock` was pushed to `${{ github.head_ref || github.ref_name }}`
+          commit-message: Updating requirements.txt after change to `pdm.lock` was pushed to `${{ github.ref_name }}`
           delete-branch: true

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - bioRxiv-v1
+      - dev
     paths:
       - "pdm.lock"
 


### PR DESCRIPTION
# Context
The Make Requirements github action automatically updates the `requirements.txt` files and opens a PR to merge the changes. However, it only looks at the `main` branch, so it didn't run when the last dependency changes were made.

# Changes
Track the `bioRxiv-v1` and `dev` branches.

# Testing
 PR #41 was created by the updated action with the correct base branch (not main)

# Other notes
This change should fix the github action for future changes to the dependencies. For the changes from 2 months ago (updating colorizer-data), I'm going to manually run the action.