### PR TITLE
fix feeding control and inhibitor errors in global dataset filtering

### DIFF
--- a/nuc_morph_analysis/lib/preprocessing/global_dataset_filtering.py
+++ b/nuc_morph_analysis/lib/preprocessing/global_dataset_filtering.py
@@ -207,16 +207,17 @@ def process_all_tracks(df, dataset, remove_growth_outliers, num_workers):
     df = add_change_over_time(df)
     df = add_features.add_volume_change_over_25_minute_window(df)
 
-    df = add_neighborhood_avg_features.run_script(df, num_workers=num_workers)
-    df = add_neighborhood_avg_features_lrm.run_script(df, num_workers=num_workers, 
-                                                feature_list=["volume", "height", "xy_aspect", "mesh_sa", "2d_area_nuc_cell_ratio"],
-                                                exclude_outliers=True)
-
     if dataset == "all_baseline":
+        
+        df = add_neighborhood_avg_features.run_script(df, num_workers=num_workers)
+        df = add_neighborhood_avg_features_lrm.run_script(df, num_workers=num_workers, 
+                                                    feature_list=["volume", "height", "xy_aspect", "mesh_sa", "2d_area_nuc_cell_ratio"],
+                                                    exclude_outliers=True)
+
         df = add_colony_time_all_datasets(df)
 
-    df = add_features.add_perimeter_ratio(df)
-    df = filter_data.apply_density_related_filters(df)
+        df = add_features.add_perimeter_ratio(df)
+        df = filter_data.apply_density_related_filters(df)
     assert df.index.name == "CellId"
     return df
 
@@ -268,23 +269,25 @@ def process_full_tracks(df_all, thresh, pix_size, interval):
     df_full = add_features.add_fold_change_track_fromB(df_full, "SA", "mesh_sa", pix_size**2)
     df_full = add_growth_features.add_early_growth_rate(df_full, interval)
     df_full = add_growth_features.add_late_growth_rate_by_endpoints(df_full)
-    df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "power",add_fit_volume=True) #add_fit_volume=True, used for volume dip detection
-    df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "exponential")
-    df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "linear")
-    
-    # For LRM
-    df_full = add_features.add_lineage_features(df_full, feature_list=['volume_at_B', 'duration_BC', 'volume_at_C', 'delta_volume_BC'])
-    df_full = add_features.add_feature_at(df_full, "frame_transition", 'height', 'height_percentile', pix_size) 
-    df_full = add_features.add_features_at_transition(df_full)
-    df_full = add_features.get_early_transient_gr_of_neighborhood(df_full, scale=get_plot_labels_for_metric('neighbor_avg_dxdt_48_volume_90um')[0])
 
-    df_full = filter_out_dips.run_script(df_full)
-    df_full = compute_change_over_time.run_script(df_full, dxdt_feature_list=['volume_dips_removed_um_unfilled'], bin_interval_list=[48])
-    df_full = add_neighborhood_avg_features.run_script(df_full, feature_list=['dxdt_48_volume_dips_removed_um_unfilled'])
+    if dataset in "all_baseline":
+        df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "power",add_fit_volume=True) #add_fit_volume=True, used for volume dip detection
+        df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "exponential")
+        df_full = add_growth_features.fit_tracks_to_model(df_full, interval, "linear")
+        
+        # For LRM
+        df_full = add_features.add_lineage_features(df_full, feature_list=['volume_at_B', 'duration_BC', 'volume_at_C', 'delta_volume_BC'])
+        df_full = add_features.add_feature_at(df_full, "frame_transition", 'height', 'height_percentile', pix_size) 
+        df_full = add_features.add_features_at_transition(df_full)
+        df_full = add_features.get_early_transient_gr_of_neighborhood(df_full, scale=get_plot_labels_for_metric('neighbor_avg_dxdt_48_volume_90um')[0])
 
-    df_full = add_features.sum_mitotic_events_along_full_track(df_full)
-    df_full = add_features.normalize_sum_events(df_full)
-    df_full = add_features.add_mean_features(df_full)
+        df_full = filter_out_dips.run_script(df_full)
+        df_full = compute_change_over_time.run_script(df_full, dxdt_feature_list=['volume_dips_removed_um_unfilled'], bin_interval_list=[48])
+        df_full = add_neighborhood_avg_features.run_script(df_full, feature_list=['dxdt_48_volume_dips_removed_um_unfilled'])
+
+        df_full = add_features.sum_mitotic_events_along_full_track(df_full)
+        df_full = add_features.normalize_sum_events(df_full)
+        df_full = add_features.add_mean_features(df_full)
 
     # Add flag for use after merging back to main manifest
     df_full = add_features.add_full_track_flag(df_full)


### PR DESCRIPTION
# Purpose
Fix the errors that occur in global_dataset_filtering when processing "all_feeding_control" and  "all_drug_perturbation" datasets. 

# Changes
Use an `if` statement to exclude "all_feeding_control" and  "all_drug_perturbation" from workflows that require density features or other features not present in the manifests after "generate_perturbation_maniftests"

# Tests
`pdm run python run_all_manuscript_workflows.py --only figure_s12_feeding_control figure_s6_s16_inhibitors
====== Successes ======
figure_s12_feeding_control (152.2s) (14.7GB)
figure_s6_s16_inhibitors (154.8s) (11.6GB)
====== 2 succeeded  ======

### Example outputs look correct!
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d51b5307-0cc1-4fa1-b076-d767817036d1">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a8d4c4d7-4d8d-4ee8-b161-f0de0bf8e6a2">
