### PR TITLE
adjust suppFigS9F percent cutoff

### DIFF
--- a/nuc_morph_analysis/analyses/volume/figure_5_s9_workflow.py
+++ b/nuc_morph_analysis/analyses/volume/figure_5_s9_workflow.py
@@ -156,11 +156,11 @@ plt.close()
 # %% Calculate average growth rate over beginning and end subsets of tracks
 
 # only choose values from defined regions of normalized interphase time
-t1 = 0.3
-t2 = 0.75
+t1 = 0.5
+t2 = 0.5
 dfin = add_binned_normalized_time_for_full_tracks(df_full)
-df_t1 = dfin[(dfin["digitized_normalized_time"] < t1)].groupby("track_id").agg("mean")
-df_t2 = dfin[(dfin["digitized_normalized_time"] > t2)].groupby("track_id").agg("mean")
+df_t1 = dfin[(dfin["normalized_time"] < t1)].groupby("track_id").agg("mean")
+df_t2 = dfin[(dfin["normalized_time"] > t2)].groupby("track_id").agg("mean")
 
 # now require that the track_id is in both dfq1 and dfq2
 df_t1 = df_t1[df_t1.index.isin(df_t2.index)]


### PR DESCRIPTION
# Goal: adjust analysis of SuppFigS9F to use symmetric time windows
Previous analysis compared data from first 30% and last 25% of tracks. New version of analysis selects data from first 50% and last 50% of tracks. 

# Outcome
#### old plot
<img width="200" alt="image" src="https://github.com/user-attachments/assets/1a979703-efe3-4cf4-b234-8d8451ca144c" />

#### new plot
<img width="200" alt="image" src="https://github.com/user-attachments/assets/96aad446-3fe5-4aa4-b275-6a9a9c86f99e" />

#### new plot as it looks in figure
<img width="208" alt="image" src="https://github.com/user-attachments/assets/02b2d2b0-fabc-48c8-8639-efe8d2957c0d" />

# Changes
Only 1 file was changed: `nuc_morph_analysis/analyses/volume/figure_5_s9_workflow.py`
The N value in the previous analysis was N=786 (much, much lower than 1166). This is because the time windows chosen previously (first 30% and last 25%) were too short. Note: switching from `digitized_normalized_time` to `normalized_time` is a robustness improvement; it prevents rounding errors in binning the normalized time from excluding cells.

# Tests
`pdm run python nuc_morph_analysis/analyses/volume/figure_5_s9_workflow.py` ran without error. 
No need for extensive testing beyond this because this was the only file that was changed.  
