### PR TITLE
Remove `aicsfiles` from `requirements.txt`

### DIFF
--- a/.github/actions/pdm/action.yml
+++ b/.github/actions/pdm/action.yml
@@ -3,6 +3,9 @@ description: Install PDM from our version
 runs:
   using: composite
   steps:
+    - name: Install Python for PDM
+      # This action reads the Python version from .python-version
+      uses: actions/setup-python@v6
     - name: Set up PDM
       uses: pdm-project/setup-pdm@c050bdcb2405837648035b6678c75609d53a749f
       with:

--- a/.github/actions/pdm/action.yml
+++ b/.github/actions/pdm/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Install Python for PDM
       # This action reads the Python version from .python-version
+      # PDM 2.12.2 doesn't install properly on Python 3.14
       uses: actions/setup-python@v6
     - name: Set up PDM
       uses: pdm-project/setup-pdm@c050bdcb2405837648035b6678c75609d53a749f

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -57,7 +57,7 @@ jobs:
           esac
 
       - name: Upload requirements files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.platform.outputs.platform }}-requirements
           path: requirements/${{ steps.platform.outputs.platform }}
@@ -74,13 +74,13 @@ jobs:
           path: requirements/linux
 
       - name: Download windows requirements files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: windows-requirements
           path: requirements/windows
 
       - name: Download macOS requirements files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: macos-requirements
           path: requirements/macos

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/pdm
 
       - name: Generate requirements.txt
@@ -66,9 +66,9 @@ jobs:
     needs: [make-requirements]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Download linux requirements files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: linux-requirements
           path: requirements/linux

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -94,7 +94,7 @@ jobs:
         run: echo "::set-output name=timestamp::$(date +'%Y-%m-%d_%H-%M')"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           base: ${{ github.ref_name }}
           title: admin/requirements-update_${{ steps.timestamp.outputs.timestamp }}

--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -38,7 +38,7 @@ jobs:
 
           rm -rf requirements/*
           mkdir -p requirements/$PLATFORM
-          pdm requirements requirements/$PLATFORM/requirements.txt
+          pdm requirements requirements/$PLATFORM/requirements.txt -d
 
       - name: Get platform variable
         id: platform

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -38,10 +38,10 @@ python install-pdm.py
 > [!WARNING]
 > With this installation method `pdm` will be tied to the exact python version used to install it. If you installed with Python 3.9.13, for example, and you later transition to Python 3.9.17, do not uninstall Python 3.9.13.
 
-`pdm` will be installed into `$HOME/.local/bin`. Check that your version is at least 2.10.
+`pdm` will be installed into `$HOME/.local/bin`. Check that your version is at least 2.10. We test against version 2.12.2.
 ```bash
 $ pdm --version
-PDM, version 2.10.4
+PDM, version 2.12.2
 ```
 
 ## Install the project dependencies

--- a/requirements/linux/requirements.txt
+++ b/requirements/linux/requirements.txt
@@ -2,7 +2,6 @@
 # Please do not edit it manually.
 
 aicscytoparam==0.1.10
-aicsfiles==5.1.0
 aicsimageio==4.14.0
 aicsshparam==0.1.7
 aiohttp==3.9.3
@@ -17,7 +16,6 @@ asttokens==2.4.1
 async-timeout==4.0.3; python_version < "3.11"
 attrs==23.2.0
 av==12.3.0
-backoff==1.11.1
 beautifulsoup4==4.12.3
 bigtree==0.19.3
 bioio==1.0.3
@@ -69,7 +67,6 @@ jedi==0.19.1
 jinja2==3.1.3
 jmespath==1.0.1
 joblib==1.3.2
-jsonpickle==2.2.0
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
@@ -79,9 +76,7 @@ jupyter-core==5.7.1
 jupyterlab-pygments==0.3.0
 jupyterlab-widgets==3.0.11
 kiwisolver==1.4.5
-labkey==1.4.1
 lazy-loader==0.3
-lkaccess==1.4.25
 locket==1.0.0
 lxml==4.9.4
 lxml-stubs==0.5.1
@@ -125,7 +120,6 @@ prompt-toolkit==3.0.43
 psutil==5.9.8
 ptyprocess==0.7.0; sys_platform != "win32" or os_name != "nt"
 pure-eval==0.2.2
-pyaml==20.4.0
 pyarrow==17.0.0
 pycparser==2.21
 pydantic==2.6.0
@@ -143,7 +137,6 @@ pyzmq==25.1.2
 qtconsole==5.5.1
 qtpy==2.4.1
 referencing==0.33.0
-rehash==1.0.1
 requests==2.31.0
 resource-backed-dask-array==0.1.0
 rich==13.7.1
@@ -163,7 +156,6 @@ sortedcontainers==2.4.0
 soupsieve==2.5
 stack-data==0.6.3
 tblib==3.0.0
-tenacity==8.1.0
 termcolor==2.4.0
 terminado==0.18.0
 threadpoolctl==3.2.0

--- a/requirements/macos/requirements.txt
+++ b/requirements/macos/requirements.txt
@@ -2,7 +2,6 @@
 # Please do not edit it manually.
 
 aicscytoparam==0.1.10
-aicsfiles==5.1.0
 aicsimageio==4.14.0
 aicsshparam==0.1.7
 aiohttp==3.9.3
@@ -17,7 +16,6 @@ asttokens==2.4.1
 async-timeout==4.0.3; python_version < "3.11"
 attrs==23.2.0
 av==12.3.0
-backoff==1.11.1
 beautifulsoup4==4.12.3
 bigtree==0.19.3
 bioio==1.0.3
@@ -69,7 +67,6 @@ jedi==0.19.1
 jinja2==3.1.3
 jmespath==1.0.1
 joblib==1.3.2
-jsonpickle==2.2.0
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
@@ -79,9 +76,7 @@ jupyter-core==5.7.1
 jupyterlab-pygments==0.3.0
 jupyterlab-widgets==3.0.11
 kiwisolver==1.4.5
-labkey==1.4.1
 lazy-loader==0.3
-lkaccess==1.4.25
 locket==1.0.0
 lxml==4.9.4
 lxml-stubs==0.5.1
@@ -125,7 +120,6 @@ prompt-toolkit==3.0.43
 psutil==5.9.8
 ptyprocess==0.7.0; sys_platform != "win32" or os_name != "nt"
 pure-eval==0.2.2
-pyaml==20.4.0
 pyarrow==17.0.0
 pycparser==2.21
 pydantic==2.6.0
@@ -143,7 +137,6 @@ pyzmq==25.1.2
 qtconsole==5.5.1
 qtpy==2.4.1
 referencing==0.33.0
-rehash==1.0.1
 requests==2.31.0
 resource-backed-dask-array==0.1.0
 rich==13.7.1
@@ -163,7 +156,6 @@ sortedcontainers==2.4.0
 soupsieve==2.5
 stack-data==0.6.3
 tblib==3.0.0
-tenacity==8.1.0
 termcolor==2.4.0
 terminado==0.18.0
 threadpoolctl==3.2.0

--- a/requirements/windows/requirements.txt
+++ b/requirements/windows/requirements.txt
@@ -2,7 +2,6 @@
 # Please do not edit it manually.
 
 aicscytoparam==0.1.10
-aicsfiles==5.1.0
 aicsimageio==4.14.0
 aicsshparam==0.1.7
 aiohttp==3.9.3
@@ -17,7 +16,6 @@ asttokens==2.4.1
 async-timeout==4.0.3; python_version < "3.11"
 attrs==23.2.0
 av==12.3.0
-backoff==1.11.1
 beautifulsoup4==4.12.3
 bigtree==0.19.3
 bioio==1.0.3
@@ -69,7 +67,6 @@ jedi==0.19.1
 jinja2==3.1.3
 jmespath==1.0.1
 joblib==1.3.2
-jsonpickle==2.2.0
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
@@ -79,9 +76,7 @@ jupyter-core==5.7.1
 jupyterlab-pygments==0.3.0
 jupyterlab-widgets==3.0.11
 kiwisolver==1.4.5
-labkey==1.4.1
 lazy-loader==0.3
-lkaccess==1.4.25
 locket==1.0.0
 lxml==4.9.4
 lxml-stubs==0.5.1
@@ -125,7 +120,6 @@ prompt-toolkit==3.0.43
 psutil==5.9.8
 ptyprocess==0.7.0; sys_platform != "win32" or os_name != "nt"
 pure-eval==0.2.2
-pyaml==20.4.0
 pyarrow==17.0.0
 pycparser==2.21
 pydantic==2.6.0
@@ -143,7 +137,6 @@ pyzmq==25.1.2
 qtconsole==5.5.1
 qtpy==2.4.1
 referencing==0.33.0
-rehash==1.0.1
 requests==2.31.0
 resource-backed-dask-array==0.1.0
 rich==13.7.1
@@ -163,7 +156,6 @@ sortedcontainers==2.4.0
 soupsieve==2.5
 stack-data==0.6.3
 tblib==3.0.0
-tenacity==8.1.0
 termcolor==2.4.0
 terminado==0.18.0
 threadpoolctl==3.2.0


### PR DESCRIPTION
# Purpose
For non-AICS users, the `requirements.txt` files shouldn't include `aicsfiles`.

# Changes
* Add the `-d` flag to the `pdm requirements` command to ignore `aicsfiles` in the `internal` dependency group
* Install python (3.9) from pyenv instead of using the default python on the github actions runner, which has now updated to 3.14. 3.14 is incompatible with the old pdm version we're on (2.12.2).
* Update the github actions dependencies (checkout, download-artifact, upload-artifact, and peter-evans/create-pull-request). The previous versions were too old to run on github anymore.
* Mention in the `pdm` docs that 2.12.2 is the version we test against, in case that helps someone debug.

# Testing
* The make-requirements action is [working](https://github.com/AllenCell/nuc-morph-analysis/pull/62), and its results are part of this PR.
* Tests are passing in CI
* Still in progress:
  * [x] `pdm run python run_all_manuscript_workflows.py` with virtual env from `requirements.txt`