### PR TITLE
Clarify supported operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The data used in this analysis are publicly available on [Quilt](https://open.qu
 > [!NOTE]
 > These are the basic installation steps. However, our recommendation is to install with `pyenv` and `pdm`. See advanced installation instructions [here](docs/INSTALL.md).
 
-1. Install Python 3.9 and `git`.  Update pip at least to `24.0.0`.
+This analysis is tested on Ubuntu 18.04. Other operating systems may work, but there are known dependency issues with MacOS.
+
+1. Install Python 3.9 and `git`.  Update pip at least to `24.0.0`. Confirm your versions with `python --version` and `pip --version`.
 2. Clone this git repository.
 ```bash
 git clone git@github.com:AllenCell/nuc-morph-analysis.git


### PR DESCRIPTION
# Context
Though we provide `requirements.txt` files for MacOS and Windows, I think these have never been tested. @jcass11 recently tried to install the environment on MacOS and found that `vtk-osmesa` is not available.

# Changes
* Clarify that we've only tested on Ubuntu 18.04
* Add a disclaimer about MacOS
* Users are likely to have other Python versions installed alongside 3.9 (especially since 3.9 has reached end of life), so I added an explicit note to check `python --version` (the [advanced install instructions](https://github.com/AllenCell/nuc-morph-analysis/blob/dev/docs/INSTALL.md) walk through how to use pyenv)